### PR TITLE
ci(build): update Flutter setup in GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy_github_pages.yml
+++ b/.github/workflows/deploy_github_pages.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2.21.0
         with:
-          flutter-version: "3.38.3"
-          channel: "stable"
+          channel: stable
+          flutter-version-file: pubspec.yaml
           cache: true
 
       - name: Get dependencies


### PR DESCRIPTION
- Update flutter-action to v2.21.0
- Use flutter-version-file from pubspec.yaml instead of hardcoded version
- Adjust channel specification for consistency